### PR TITLE
parse lat/lon with a , decimal separator

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,6 +96,9 @@ function csv2geojson(x, options, callback) {
                 lonf, latf,
                 a;
 
+            lonk = lonk.replace(',', '.');
+            latk = latk.replace(',', '.');
+
             a = sexagesimal(lonk, 'EW');
             if (a) lonk = a;
             a = sexagesimal(latk, 'NS');


### PR DESCRIPTION
It appears that sometimes software such as Tableau outputs lat/lon pairs with ',' decimal separators (used in french for exemple).
This replaces them with a dot separator.
