### PR TITLE
Add CRS support for point data

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Options:
   --lat        the name of the latitude column
   --lon        the name of the longitude column
   --delimiter  the type of delimiter             [default: ","]
+  --crs        the Coordinate Reference System(CRS) of the coordinates in the GeoJSON
 ```
 
 ## Using in nodejs

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ files into [GeoJSON](http://www.geojson.org/) data suitable for maps..
 
 ```
 ➟ csv2geojson
-Usage: csv2geojson -lat [string] -lon [string] -delimiter [string] FILE
+Usage: csv2geojson -lat [string] -lon [string] -delimiter [string] -crs [string] FILE
 
 Options:
   --lat        the name of the latitude column

--- a/csv2geojson.js
+++ b/csv2geojson.js
@@ -53,7 +53,8 @@ function csv2geojson(x, options, callback) {
     options.delimiter = options.delimiter || ',';
 
     var latfield = options.latfield || '',
-        lonfield = options.lonfield || '';
+        lonfield = options.lonfield || '',
+        crs = options.crs || '';
 
     var features = [],
         featurecollection = { type: 'FeatureCollection', features: features };
@@ -105,6 +106,11 @@ function csv2geojson(x, options, callback) {
 
             lonf = parseFloat(lonk);
             latf = parseFloat(latk);
+            
+            var CRS = [];
+            if (crs !='') {
+                CRS = { type: 'name', properties: { name: crs } };
+            }
 
             if (isNaN(lonf) ||
                 isNaN(latf)) {
@@ -127,7 +133,8 @@ function csv2geojson(x, options, callback) {
                             parseFloat(lonf),
                             parseFloat(latf)
                         ]
-                    }
+                    },
+                    crs: CRS
                 });
             }
         }


### PR DESCRIPTION
The changes allow a Coordinate Reference System (CRS) name to be passed as an option to be used when converting a csv2geojson. The CRS name is then included when creating the new GeoJSON file which may not be using lat/long data, but instead might be using a custom x/y coordinate system, or alternative spatial model.
This allows this leaflet plug-in to work with Proj4-leaflet in projecting custom coordinate csv data onto a map.

Example Code(using Proj4Leaflet to display custom coordinates used in GeoJSON):

var CSVLayer = new L.Proj.geoJson(null); // initialize blank layer

csv2geojson.csv2geojson('test.csv', {
lonfield: 'y',
latfield: 'x',
crs: 'urn:ogc:def:crs:EPSG::2263' //Passing the NY Long Island State Plane Coordinate System name to be used in the GeoJSON.
},CSVLayer)
.addTo(map); //Adding new point layer to map.
//Note: you will need to define the coordinate system before you can project it.

This will then convert:

x,y,name
990629.0, 207012.0,"Point 1"
980233.0, 205015.0,"Point 2"

into:

{
"type": "FeatureCollection",
"features": [
{
"type": "Feature",
"properties": {
"name": "Point 1"
},
"geometry": {
"type": "Point",
"coordinates": [
990629,
207012
]
},
"crs": {
"type": "name",
"properties": {
"name": "urn:ogc:def:crs:EPSG::2263"
}
}
},
{
"type": "Feature",
"properties": {
"name": "Point 2"
},
"geometry": {
"type": "Point",
"coordinates": [
980233,
205015
]
},
"crs": {
"type": "name",
"properties": {
"name": "urn:ogc:def:crs:EPSG::2263"
}
}
}
]
}
