### PR TITLE
Remove sys. Use util instead.

### DIFF
--- a/csv2geojson
+++ b/csv2geojson
@@ -2,7 +2,7 @@
 
 var optimist = require('optimist'),
     fs = require('fs'),
-    sys = require('sys'),
+    sys = require('util'),
     concat = require('concat-stream'),
     csv2geojson = require('./'),
     argv = optimist

--- a/csv2geojson
+++ b/csv2geojson
@@ -2,7 +2,6 @@
 
 var optimist = require('optimist'),
     fs = require('fs'),
-    sys = require('util'),
     concat = require('concat-stream'),
     csv2geojson = require('./'),
     argv = optimist


### PR DESCRIPTION
Remove warning: (node) sys is deprecated. Use util instead.
https://github.com/nodejs/node-v0.x-archive/wiki/deprecation
