### PR TITLE
Allow geometry to be null as by spec

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,24 +85,30 @@ function csv2geojson(x, options, callback) {
 
     if (!parsed.length) return callback(null, featurecollection);
 
+    var errors = [];
+
+    var noGeometry = false;
+
     if (!latfield || !lonfield) {
         for (var f in parsed[0]) {
             if (!latfield && isLat(f)) latfield = f;
             if (!lonfield && isLon(f)) lonfield = f;
         }
         if (!latfield || !lonfield) {
-            var fields = [];
-            for (var k in parsed[0]) fields.push(k);
-            return callback({
-                type: 'Error',
-                message: 'Latitude and longitude fields not present',
-                data: deleteColumns(parsed),
-                fields: fields
-            });
+            noGeometry = true;
         }
     }
 
-    var errors = [];
+    if (noGeometry) {
+      for (var i = 0; i < parsed.length; i++) {
+        features.push({
+            type: 'Feature',
+            properties: parsed[i],
+            geometry: null
+        });
+      }
+      callback(errors.length ? errors: null, featurecollection);
+    }
 
     for (var i = 0; i < parsed.length; i++) {
         if (parsed[i][lonfield] !== undefined &&

--- a/test/csv2geojson.js
+++ b/test/csv2geojson.js
@@ -223,14 +223,9 @@ describe('csv2geojson', function() {
         });
 
         it('returns an error on not finding fields', function() {
-            csv2geojson.csv2geojson('name\nfoo', function(err, data) {
-                expect(err).to.eql({
-                    type: 'Error',
-                    message: 'Latitude and longitude fields not present',
-                    data: [{name:'foo'}],
-                    fields: ['name']
-                });
-            });
+          csv2geojson.csv2geojson(textFile('geometry_null.csv'), function(err, data) {
+              expect(data).to.eql(jsonFile('geometry_null.geojson'));
+          });
         });
     });
 });

--- a/test/data/geometry_null.csv
+++ b/test/data/geometry_null.csv
@@ -1,0 +1,2 @@
+name
+foo

--- a/test/data/geometry_null.geojson
+++ b/test/data/geometry_null.geojson
@@ -1,0 +1,10 @@
+{
+    "type": "FeatureCollection",
+    "features": [{
+        "type": "Feature",
+        "properties": {
+            "name": "foo"
+        },
+        "geometry": null
+    }]
+}


### PR DESCRIPTION
If no lat/lng are detected output null for the geometry. As you may know this is [valid by the spec](http://geojson.org/geojson-spec.html#feature-objects). This was useful to me, so it may also be for others.
