### PR TITLE
license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "bin": {
     "csv2geojson": "csv2geojson"
   },
-  "license": "BSD",
+  "license": "Unlicense",
   "devDependencies": {
     "browserify": "^8.1.3",
     "expect.js": "~0.2.0",


### PR DESCRIPTION
the license field in package.json should reflect the licence present in the `LICENSE` file
